### PR TITLE
Make use of sylius_core.public_dir by default

### DIFF
--- a/Command/AssetsInstallCommand.php
+++ b/Command/AssetsInstallCommand.php
@@ -34,7 +34,7 @@ final class AssetsInstallCommand extends ContainerAwareCommand
         $this
             ->setName('sylius:theme:assets:install')
             ->setDefinition([
-                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web'),
+                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory'),
             ])
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')
@@ -65,7 +65,13 @@ final class AssetsInstallCommand extends ContainerAwareCommand
             $symlinkMask = max($symlinkMask, AssetsInstallerInterface::RELATIVE_SYMLINK);
         }
 
-        $assetsInstaller->installAssets($input->getArgument('target'), $symlinkMask);
+        $targetDir = $this->getContainer()->getParameter('sylius_core.public_dir');
+
+        if ($input->getArgument('target')) {
+            $targetDir = $input->getArgument('target');
+        }
+
+        $assetsInstaller->installAssets($targetDir, $symlinkMask);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no/yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Fixes https://github.com/Sylius/Sylius/issues/9849
| License         | MIT


That should fix that reverted commit - https://github.com/Sylius/SyliusThemeBundle/commit/108455f9f1479a068540cb62c5bfd503f366a726