### PR TITLE
[HotFix] Allow to pass `TemplateReference` to `findTemplate` function

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,3 +22,6 @@ parameters:
         # Symfony caveats
         - '/Parameter \#1 \$name of method Symfony\\Component\\Config\\FileLocatorInterface::locate\(\) expects string, Symfony\\Component\\Templating\\TemplateReferenceInterface given/'
         - '/Parameter \#1 \$translator of class Symfony\\Component\\Translation\\Formatter\\MessageFormatter constructor expects Symfony\\Contracts\\Translation\\TranslatorInterface|null, Symfony\\Component\\Translation\\MessageSelector given/'
+
+        # Symfony passes TemplateReference object instead of a string
+        - "/Casting to string something that\\'s already string./"

--- a/spec/Twig/ThemeFilesystemLoaderSpec.php
+++ b/spec/Twig/ThemeFilesystemLoaderSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ThemeBundle\Twig;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Templating\TemplateNameParserInterface;
+use Symfony\Component\Templating\TemplateReferenceInterface;
+
+final class ThemeFilesystemLoaderSpec extends ObjectBehavior
+{
+    function let(
+        \Twig_LoaderInterface $decoratedLoader,
+        FileLocatorInterface $templateLocator,
+        TemplateNameParserInterface $templateNameParser
+    ): void {
+        $this->beConstructedWith($decoratedLoader, $templateLocator, $templateNameParser);
+    }
+
+    function it_get_cache_key_for_a_template_name(
+        TemplateNameParserInterface $templateNameParser,
+        FileLocatorInterface $templateLocator
+    ): void {
+        $templateNameParser->parse('theme_test')->willReturn('@Theme/test');
+        $templateLocator->locate('@Theme/test')->willReturn('file');
+
+        $this->getCacheKey('theme_test')->shouldReturn('file');
+    }
+
+    function it_get_cache_key_for_a_template_reference(
+        TemplateNameParserInterface $templateNameParser,
+        FileLocatorInterface $templateLocator,
+        TemplateReferenceInterface $templateReference
+    ): void {
+        $templateReference->__toString()->willReturn('theme_test');
+
+        $templateNameParser->parse('theme_test')->willReturn('@Theme/test');
+        $templateLocator->locate('@Theme/test')->willReturn('file');
+
+        $this->getCacheKey('theme_test')->shouldReturn('file');
+    }
+}

--- a/src/Twig/ThemeFilesystemLoader.php
+++ b/src/Twig/ThemeFilesystemLoader.php
@@ -60,7 +60,7 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
     public function getCacheKey($name): string
     {
         try {
-            return $this->findTemplate($name);
+            return $this->findTemplate((string) $name);
         } catch (\Exception $exception) {
             return $this->decoratedLoader->getCacheKey($name);
         }
@@ -90,7 +90,7 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
         }
     }
 
-    private function findTemplate(string $logicalName): string
+    private function findTemplate($logicalName): string
     {
         if (isset($this->cache[$logicalName])) {
             return $this->cache[$logicalName];


### PR DESCRIPTION
Sylius build is failing because of that: https://travis-ci.org/Sylius/Sylius/jobs/499069177#L743