### PR TITLE
Move string parsing to `findTemplate` method

### DIFF
--- a/spec/Twig/ThemeFilesystemLoaderSpec.php
+++ b/spec/Twig/ThemeFilesystemLoaderSpec.php
@@ -28,7 +28,7 @@ final class ThemeFilesystemLoaderSpec extends ObjectBehavior
         $this->beConstructedWith($decoratedLoader, $templateLocator, $templateNameParser);
     }
 
-    function it_get_cache_key_for_a_template_name(
+    function it_gets_source_context_for_a_template_name(
         TemplateNameParserInterface $templateNameParser,
         FileLocatorInterface $templateLocator
     ): void {
@@ -38,7 +38,7 @@ final class ThemeFilesystemLoaderSpec extends ObjectBehavior
         $this->getCacheKey('theme_test')->shouldReturn('file');
     }
 
-    function it_get_cache_key_for_a_template_reference(
+    function it_gets_cache_key_for_a_template_reference(
         TemplateNameParserInterface $templateNameParser,
         FileLocatorInterface $templateLocator,
         TemplateReferenceInterface $templateReference

--- a/src/Twig/ThemeFilesystemLoader.php
+++ b/src/Twig/ThemeFilesystemLoader.php
@@ -60,7 +60,7 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
     public function getCacheKey($name): string
     {
         try {
-            return $this->findTemplate((string) $name);
+            return $this->findTemplate($name);
         } catch (\Exception $exception) {
             return $this->decoratedLoader->getCacheKey($name);
         }
@@ -92,6 +92,8 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
 
     private function findTemplate($logicalName): string
     {
+        $logicalName = (string) $logicalName;
+
         if (isset($this->cache[$logicalName])) {
             return $this->cache[$logicalName];
         }


### PR DESCRIPTION
I've omitted tests for the other functions, cause as far as I checked, there are no places where they're used with none-string objects. Fixes https://github.com/Sylius/SyliusThemeBundle/pull/19#discussion_r260784462