### PR TITLE
Cast name from TemplateReference to string before passing to Twig_Source

### DIFF
--- a/src/Twig/ThemeFilesystemLoader.php
+++ b/src/Twig/ThemeFilesystemLoader.php
@@ -48,7 +48,7 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
         try {
             $path = $this->findTemplate($name);
 
-            return new \Twig_Source((string) file_get_contents($path), $name, $path);
+            return new \Twig_Source((string) file_get_contents($path), (string) $name, $path);
         } catch (\Exception $exception) {
             return $this->decoratedLoader->getSourceContext($name);
         }


### PR DESCRIPTION
I'm not sure if this is the only one, but this is definitely a part of the conflict-2.7.3 