### PR TITLE
TranslatorInterface and Symfony3. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/asset": "^3.4|^4.1.1",
         "symfony/config": "^3.4|^4.1.1",
         "symfony/console": "^3.4|^4.1.1",
+        "symfony/contracts": "^1.0",
         "symfony/dependency-injection": "^3.4|^4.1.1",
         "symfony/filesystem": "^3.4|^4.1.1",
         "symfony/finder": "^3.4|^4.1.1",

--- a/spec/Translation/ThemeAwareTranslatorSpec.php
+++ b/spec/Translation/ThemeAwareTranslatorSpec.php
@@ -19,11 +19,12 @@ use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class ThemeAwareTranslatorSpec extends ObjectBehavior
 {
-    function let(TranslatorInterface $translator, ThemeContextInterface $themeContext): void
+    function let(LegacyTranslatorInterface $translator, ThemeContextInterface $themeContext): void
     {
         $translator->implement(TranslatorBagInterface::class);
 
@@ -33,6 +34,11 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
     function it_implements_translator_interface(): void
     {
         $this->shouldImplement(TranslatorInterface::class);
+    }
+
+    function it_implements_legacy_translator_interface(): void
+    {
+        $this->shouldImplement(LegacyTranslatorInterface::class);
     }
 
     function it_implements_translator_bag_interface(): void
@@ -45,14 +51,14 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
         $this->shouldImplement(WarmableInterface::class);
     }
 
-    function it_proxies_getting_the_locale_to_the_decorated_translator(TranslatorInterface $translator): void
+    function it_proxies_getting_the_locale_to_the_decorated_translator(LegacyTranslatorInterface $translator): void
     {
         $translator->getLocale()->willReturn('pl_PL');
 
         $this->getLocale()->shouldReturn('pl_PL');
     }
 
-    function it_proxies_setting_the_locale_to_the_decorated_translator(TranslatorInterface $translator): void
+    function it_proxies_setting_the_locale_to_the_decorated_translator(LegacyTranslatorInterface $translator): void
     {
         $translator->setLocale('pl_PL')->shouldBeCalled();
 
@@ -68,7 +74,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
         $this->getCatalogue('pl_PL')->shouldReturn($messageCatalogue);
     }
 
-    function it_just_proxies_translating(TranslatorInterface $translator, ThemeContextInterface $themeContext): void
+    function it_just_proxies_translating(LegacyTranslatorInterface $translator, ThemeContextInterface $themeContext): void
     {
         $themeContext->getTheme()->willReturn(null);
 
@@ -77,7 +83,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
         $this->trans('id', ['param'], 'domain')->shouldReturn('translated string');
     }
 
-    function it_just_proxies_translating_with_custom_locale(TranslatorInterface $translator, ThemeContextInterface $themeContext): void
+    function it_just_proxies_translating_with_custom_locale(LegacyTranslatorInterface $translator, ThemeContextInterface $themeContext): void
     {
         $themeContext->getTheme()->willReturn(null);
 
@@ -87,7 +93,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
     }
 
     function it_proxies_translating_with_modified_default_locale(
-        TranslatorInterface $translator,
+        LegacyTranslatorInterface $translator,
         ThemeContextInterface $themeContext,
         ThemeInterface $theme
     ): void {
@@ -101,7 +107,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
     }
 
     function it_proxies_translating_with_modified_custom_locale(
-        TranslatorInterface $translator,
+        LegacyTranslatorInterface $translator,
         ThemeContextInterface $themeContext,
         ThemeInterface $theme
     ): void {
@@ -113,7 +119,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
         $this->trans('id', ['param'], 'domain', 'customlocale')->shouldReturn('translated string');
     }
 
-    function it_just_proxies_choice_translating(TranslatorInterface $translator, ThemeContextInterface $themeContext): void
+    function it_just_proxies_choice_translating(LegacyTranslatorInterface $translator, ThemeContextInterface $themeContext): void
     {
         $themeContext->getTheme()->willReturn(null);
 
@@ -122,7 +128,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
         $this->transChoice('id', 2, ['param'], 'domain')->shouldReturn('translated string');
     }
 
-    function it_just_proxies_choice_translating_with_custom_locale(TranslatorInterface $translator, ThemeContextInterface $themeContext): void
+    function it_just_proxies_choice_translating_with_custom_locale(LegacyTranslatorInterface $translator, ThemeContextInterface $themeContext): void
     {
         $themeContext->getTheme()->willReturn(null);
 
@@ -132,7 +138,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
     }
 
     function it_proxies_choice_translating_with_modified_default_locale(
-        TranslatorInterface $translator,
+        LegacyTranslatorInterface $translator,
         ThemeContextInterface $themeContext,
         ThemeInterface $theme
     ): void {
@@ -146,7 +152,7 @@ final class ThemeAwareTranslatorSpec extends ObjectBehavior
     }
 
     function it_proxies_choice_translating_with_modified_custom_locale(
-        TranslatorInterface $translator,
+        LegacyTranslatorInterface $translator,
         ThemeContextInterface $themeContext,
         ThemeInterface $theme
     ): void {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #26
| License         | MIT

To fix #26 I propose to use `symfony/contracts` (this package doesn't have a dependency on particular Symfony version, so I think that is a good solution). After this change, ThemeBundle is compatible with Symfony3 again. 

I change also Specs for `ThemeAwareTranslator` - but it was my first time with PhpSpec, so I'm asking for your understanding. 