### PR TITLE
Fix deprecated array_key_exists in TranslatorResourceProviderPass

### DIFF
--- a/src/Translation/DependencyInjection/Compiler/TranslatorResourceProviderPass.php
+++ b/src/Translation/DependencyInjection/Compiler/TranslatorResourceProviderPass.php
@@ -43,7 +43,7 @@ final class TranslatorResourceProviderPass implements CompilerPassInterface
         try {
             $options = $symfonyTranslator->getArgument(3);
 
-            if (!isset('resource_files', $options)) {
+            if (!is_array($options) && !isset($options['resource_files'])) {
                 $options = $symfonyTranslator->getArgument(4);
             }
         } catch (OutOfBoundsException $exception) {

--- a/src/Translation/DependencyInjection/Compiler/TranslatorResourceProviderPass.php
+++ b/src/Translation/DependencyInjection/Compiler/TranslatorResourceProviderPass.php
@@ -43,7 +43,7 @@ final class TranslatorResourceProviderPass implements CompilerPassInterface
         try {
             $options = $symfonyTranslator->getArgument(3);
 
-            if (!array_key_exists('resource_files', $options)) {
+            if (!isset('resource_files', $options)) {
                 $options = $symfonyTranslator->getArgument(4);
             }
         } catch (OutOfBoundsException $exception) {

--- a/src/Translation/DependencyInjection/Compiler/TranslatorResourceProviderPass.php
+++ b/src/Translation/DependencyInjection/Compiler/TranslatorResourceProviderPass.php
@@ -43,7 +43,7 @@ final class TranslatorResourceProviderPass implements CompilerPassInterface
         try {
             $options = $symfonyTranslator->getArgument(3);
 
-            if (!is_array($options) && !isset($options['resource_files'])) {
+            if (!is_array($options) || !isset($options['resource_files'])) {
                 $options = $symfonyTranslator->getArgument(4);
             }
         } catch (OutOfBoundsException $exception) {


### PR DESCRIPTION
Because in Symfony 5 it ends with:

```
rm -rf var/cache/
bin/console doctrine:ensure-production-settings -e prod
```

> PHP Deprecated:  array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead in /sulu-theme-bundle/vendor/sylius/theme-bundle/src/Translation/DependencyInjection/Compiler/TranslatorResourceProviderPass.php on line 46