### PR TITLE
Do not use empty string as valid locale

### DIFF
--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -311,7 +311,6 @@ final class TranslatorTest extends TestCase
     public function getThemelessLocalesTests(): array
     {
         return [
-            [''],
             ['fr'],
             ['francais'],
             ['FR'],


### PR DESCRIPTION
It seems the empty string is translated to the default locale now... 🤔  I'm not 100% sure it should work like this, but it definitely fixes the build 😄 