### PR TITLE
Fix ThemeCollector Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,9 @@
             "@composer validate --strict",
             "vendor/bin/ecs check spec src tests || true",
             "vendor/bin/psalm",
-            "vendor/bin/rector process --dry-run"
+            "vendor/bin/rector process --dry-run",
+            "tests/Application/bin/console lint:container --env dev",
+            "tests/Application/bin/console lint:container --env prod"
         ],
         "fix": [
             "vendor/bin/rector process",

--- a/src/Collector/ThemeCollector.php
+++ b/src/Collector/ThemeCollector.php
@@ -21,6 +21,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
+/**
+ * @property $data array{used_theme: ?ThemeInterface, used_themes: ThemeInterface[], themes: ThemeInterface[]}
+
+ */
 final class ThemeCollector extends DataCollector
 {
     private ThemeRepositoryInterface $themeRepository;
@@ -28,15 +32,6 @@ final class ThemeCollector extends DataCollector
     private ThemeContextInterface $themeContext;
 
     private ThemeHierarchyProviderInterface $themeHierarchyProvider;
-
-    /**
-     * @var array
-     *
-     * @psalm-var array{used_theme: ?ThemeInterface, used_themes: ThemeInterface[], themes: ThemeInterface[]}
-     *
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     */
-    protected $data;
 
     public function __construct(
         ThemeRepositoryInterface $themeRepository,

--- a/src/Collector/ThemeCollector.php
+++ b/src/Collector/ThemeCollector.php
@@ -55,7 +55,7 @@ final class ThemeCollector extends DataCollector
     }
 
     /**
-     * @return array|ThemeInterface[]
+     * @return ThemeInterface[]
      */
     public function getUsedThemes(): array
     {

--- a/src/Collector/ThemeCollector.php
+++ b/src/Collector/ThemeCollector.php
@@ -23,7 +23,6 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
 /**
  * @property $data array{used_theme: ?ThemeInterface, used_themes: ThemeInterface[], themes: ThemeInterface[]}
-
  */
 final class ThemeCollector extends DataCollector
 {

--- a/tests/Collector/ThemeCollectorTest.php
+++ b/tests/Collector/ThemeCollectorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ThemeBundle\Tests\Collector;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ThemeBundle\Collector\ThemeCollector;
+use Sylius\Bundle\ThemeBundle\Context\EmptyThemeContext;
+use Sylius\Bundle\ThemeBundle\HierarchyProvider\NoopThemeHierarchyProvider;
+use Sylius\Bundle\ThemeBundle\Loader\ThemeLoaderInterface;
+use Sylius\Bundle\ThemeBundle\Repository\InMemoryThemeRepository;
+
+class ThemeCollectorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_has_no_used_theme(): void
+    {
+        $themeCollector = $this->createThemeCollector();
+
+        $this->assertNull($themeCollector->getUsedTheme());
+    }
+
+    private function createThemeCollector(): ThemeCollector
+    {
+        $themeLoader = new class () implements ThemeLoaderInterface {
+            public function load(): array
+            {
+                return [];
+            }
+        };
+
+        $themeRepository = new InMemoryThemeRepository($themeLoader);
+        $themeContext = new EmptyThemeContext();
+        $themeHierarchyProvider = new NoopThemeHierarchyProvider();
+
+        return new ThemeCollector(
+            $themeRepository,
+            $themeContext,
+            $themeHierarchyProvider,
+        );
+    }
+}


### PR DESCRIPTION
>  PHP Fatal error:  Type of Sylius\Bundle\ThemeBundle\Collector\ThemeCollector::$data must be Symfony\Component\VarDumper\Cloner\Data|array (as in class Symfony\Component\HttpKernel\DataCollector\DataCollector) in /home/runner/work/SyliusThemeBundle/SyliusThemeBundle/src/Collector/ThemeCollector.php on line 24

I added a very simple test case which just init the ThemeCollector to catch this.