### PR TITLE
Revert "Remove performNoDeepMerging to authorise additional custom theme folders"

### DIFF
--- a/src/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
+++ b/src/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
@@ -45,6 +45,7 @@ final class FilesystemConfigurationSourceFactory implements ConfigurationSourceF
             ->arrayNode('directories')
                 ->defaultValue(['%kernel.project_dir%/themes'])
                 ->requiresAtLeastOneElement()
+                ->performNoDeepMerging()
                 ->prototype('scalar')
         ;
     }


### PR DESCRIPTION
Reverts Sylius/SyliusThemeBundle#128

I did not notice that in the PR the tests were not included and this actually changes the expected behaviour. This change has been explained in the PR, but I still have some doubts and IMO it should be further investigated how the Theme Bundle will behave in the case of the several directories specified.