### PR TITLE
PHP 8.4 fix

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -44,7 +44,7 @@ final class Filesystem implements FilesystemInterface
         return $this->filesystem->exists($files);
     }
 
-    public function touch($files, int $time = null, int $atime = null)
+    public function touch($files, ?int $time = null, ?int $atime = null)
     {
         $this->filesystem->touch($files, $time, $atime);
     }
@@ -79,7 +79,7 @@ final class Filesystem implements FilesystemInterface
         $this->filesystem->symlink($originDir, $targetDir, $copyOnWindows);
     }
 
-    public function mirror(string $originDir, string $targetDir, \Traversable $iterator = null, array $options = [])
+    public function mirror(string $originDir, string $targetDir, ?\Traversable $iterator = null, array $options = [])
     {
         $this->filesystem->mirror($originDir, $targetDir, $iterator, $options);
     }

--- a/src/Filesystem/FilesystemInterface.php
+++ b/src/Filesystem/FilesystemInterface.php
@@ -120,7 +120,7 @@ interface FilesystemInterface
      *
      * @throws IOException When file type is unknown
      */
-    public function mirror(string $originDir, string $targetDir, \Traversable $iterator = null, array $options = []);
+    public function mirror(string $originDir, string $targetDir, ?\Traversable $iterator = null, array $options = []);
 
     /**
      * Given an existing path, convert it to a path relative to a given starting path.

--- a/src/Filesystem/FilesystemInterface.php
+++ b/src/Filesystem/FilesystemInterface.php
@@ -55,7 +55,7 @@ interface FilesystemInterface
      *
      * @throws IOException When touch fails
      */
-    public function touch($files, int $time = null, int $atime = null);
+    public function touch($files, ?int $time = null, ?int $atime = null);
 
     /**
      * Removes files or directories.
@@ -76,7 +76,7 @@ interface FilesystemInterface
     public function chmod($files, int $mode, int $umask = 0000, bool $recursive = false);
 
     /**
-     * Change the owner of an array of files or directories.
+     * Change the owner of an array of files or directories.#
      *
      * @param string|array|\Traversable $files     A filename, an array of files, or a \Traversable instance to change owner
      *


### PR DESCRIPTION
Using Sylius 2.0 with PHP 8.4 some deprecation notices are displayed:

```
Deprecated: Sylius\Bundle\ThemeBundle\Filesystem\FilesystemInterface::touch(): Implicitly marking parameter $time as nullable is deprecated, the explicit nullable type must be used instead in vendor/sylius/theme-bundle/src/Filesystem/FilesystemInterface.php on line 58

Deprecated: Sylius\Bundle\ThemeBundle\Filesystem\FilesystemInterface::touch(): Implicitly marking parameter $atime as nullable is deprecated, the explicit nullable type must be used instead in vendor/sylius/theme-bundle/src/Filesystem/FilesystemInterface.php on line 58

Deprecated: Sylius\Bundle\ThemeBundle\Filesystem\FilesystemInterface::mirror(): Implicitly marking parameter $iterator as nullable is deprecated, the explicit nullable type must be used instead in vendor/sylius/theme-bundle/src/Filesystem/FilesystemInterface.php on line 123

Deprecated: Sylius\Bundle\ThemeBundle\Filesystem\Filesystem::touch(): Implicitly marking parameter $time as nullable is deprecated, the explicit nullable type must be used instead in vendor/sylius/theme-bundle/src/Filesystem/Filesystem.php on line 47

Deprecated: Sylius\Bundle\ThemeBundle\Filesystem\Filesystem::touch(): Implicitly marking parameter $atime as nullable is deprecated, the explicit nullable type must be used instead in vendor/sylius/theme-bundle/src/Filesystem/Filesystem.php on line 47

Deprecated: Sylius\Bundle\ThemeBundle\Filesystem\Filesystem::mirror(): Implicitly marking parameter $iterator as nullable is deprecated, the explicit nullable type must be used instead in vendor/sylius/theme-bundle/src/Filesystem/Filesystem.php on line 82
```