### PR TITLE
Add CI for PHP 8.4 and 8.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ "8.1", "8.2", "8.3" ]
+                php: [ "8.1", "8.2", "8.3", "8.4", "8.5" ]
                 symfony: [ "^5.4", "^6.4", "^7.0" ]
                 twig: [ "3.*" ]
 


### PR DESCRIPTION
There is currently no CI for 8.4 and 8.5.