### PR TITLE
Code cleanup and modernization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
             -
                 name: Remove analyse dependencies
                 run: |
-                    composer remove vimeo/psalm --dev --no-update
                     composer remove sylius-labs/coding-standard --dev --no-update
                     composer remove rector/rector --dev --no-update
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2021 Paweł Jędrzejewski
+Copyright (c) 2011 Sylius Sp. z o.o.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "2.5-dev"
         }
     },
     "autoload": {

--- a/src/Command/AssetsInstallCommand.php
+++ b/src/Command/AssetsInstallCommand.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ThemeBundle\Command;
 
 use Sylius\Bundle\ThemeBundle\Asset\Installer\AssetsInstallerInterface;
 use Sylius\Bundle\ThemeBundle\Asset\Installer\OutputAwareInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,6 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Command that places themes web assets into a given directory.
  */
+#[AsCommand(name: 'sylius:theme:assets:install', description: 'Installs themes web assets under a public web directory')]
 final class AssetsInstallCommand extends Command
 {
     private AssetsInstallerInterface $assetsInstaller;
@@ -33,7 +35,7 @@ final class AssetsInstallCommand extends Command
 
     public function __construct(AssetsInstallerInterface $assetsInstaller, string $projectDir)
     {
-        parent::__construct(null);
+        parent::__construct();
 
         $this->assetsInstaller = $assetsInstaller;
         $this->projectDir = $projectDir;
@@ -42,13 +44,11 @@ final class AssetsInstallCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('sylius:theme:assets:install')
             ->setDefinition([
                 new InputArgument('target', InputArgument::OPTIONAL, 'The target directory'),
             ])
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')
-            ->setDescription('Installs themes web assets under a public web directory')
             ->setHelp($this->getHelpMessage())
         ;
     }

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -14,28 +14,22 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ThemeBundle\Command;
 
 use Sylius\Bundle\ThemeBundle\Repository\ThemeRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'sylius:theme:list', description: 'Shows list of detected themes.')]
 final class ListCommand extends Command
 {
     private ThemeRepositoryInterface $themeRepository;
 
     public function __construct(ThemeRepositoryInterface $themeRepository)
     {
-        parent::__construct(null);
+        parent::__construct();
 
         $this->themeRepository = $themeRepository;
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('sylius:theme:list')
-            ->setDescription('Shows list of detected themes.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Loader/CircularDependencyFoundException.php
+++ b/src/Loader/CircularDependencyFoundException.php
@@ -20,7 +20,7 @@ final class CircularDependencyFoundException extends \DomainException
     /**
      * @param ThemeInterface[] $themes
      */
-    public function __construct(array $themes, ?\Exception $previous = null)
+    public function __construct(array $themes, ?\Throwable $previous = null)
     {
         $cycle = $this->getCycleFromArray($themes);
 

--- a/src/Translation/ThemeAwareTranslator.php
+++ b/src/Translation/ThemeAwareTranslator.php
@@ -33,18 +33,15 @@ final class ThemeAwareTranslator implements TranslatorInterface, TranslatorBagIn
     public function __construct(TranslatorInterface $translator, ThemeContextInterface $themeContext)
     {
         foreach ([LocaleAwareInterface::class, TranslatorBagInterface::class] as $interface) {
-            /** @psalm-suppress DocblockTypeContradiction Better safe than sorry */
             if (!$translator instanceof $interface) {
-                /** @psalm-suppress NoValue Better safe than sorry */
                 throw new \InvalidArgumentException(sprintf(
                     'The translator "%s" must implement %s.',
-                    get_class($translator),
+                    $translator::class,
                     $interface,
                 ));
             }
         }
 
-        /** @psalm-suppress InvalidPropertyAssignmentValue */
         $this->translator = $translator;
         $this->themeContext = $themeContext;
     }
@@ -60,21 +57,9 @@ final class ThemeAwareTranslator implements TranslatorInterface, TranslatorBagIn
         return $translator->$method(...$arguments);
     }
 
-    /**
-     * @psalm-suppress MissingParamType Two interfaces defining the same method
-     */
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         return $this->translator->trans($id, $parameters, $domain, $this->transformLocale($locale));
-    }
-
-    public function transChoice(string $id, int $number, array $parameters = [], ?string $domain = null, ?string $locale = null): string
-    {
-        if (!method_exists($this->translator, 'transChoice')) {
-            throw new \RuntimeException(sprintf('%s::transChoice is not supported with symfony/translation v5', static::class));
-        }
-
-        return $this->translator->transChoice($id, $number, $parameters, $domain, $this->transformLocale($locale));
     }
 
     public function getLocale(): string
@@ -101,10 +86,6 @@ final class ThemeAwareTranslator implements TranslatorInterface, TranslatorBagIn
         return $this->translator->getCatalogue($locale);
     }
 
-    /**
-     * @psalm-suppress MissingParamType
-     * @psalm-suppress MissingReturnType
-     */
     public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         if ($this->translator instanceof WarmableInterface) {

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -16,9 +16,7 @@ namespace Sylius\Bundle\ThemeBundle\Translation;
 use Sylius\Bundle\ThemeBundle\Translation\Provider\Loader\TranslatorLoaderProviderInterface;
 use Sylius\Bundle\ThemeBundle\Translation\Provider\Resource\TranslatorResourceProviderInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
-use Symfony\Component\Translation\Formatter\MessageFormatter;
 use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
-use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Translator as BaseTranslator;
 
 final class Translator extends BaseTranslator implements WarmableInterface
@@ -28,21 +26,16 @@ final class Translator extends BaseTranslator implements WarmableInterface
         'debug' => false,
     ];
 
-    /** @psalm-suppress PropertyNotSetInConstructor It is set in the constructor though */
     private TranslatorLoaderProviderInterface $loaderProvider;
 
-    /** @psalm-suppress PropertyNotSetInConstructor It is set in the constructor though */
     private TranslatorResourceProviderInterface $resourceProvider;
 
     private bool $resourcesLoaded = false;
 
-    /**
-     * @param MessageSelector|MessageFormatterInterface $messageFormatterOrSelector
-     */
     public function __construct(
         TranslatorLoaderProviderInterface $loaderProvider,
         TranslatorResourceProviderInterface $resourceProvider,
-        $messageFormatterOrSelector,
+        MessageFormatterInterface $messageFormatter,
         string $locale,
         array $options = [],
     ) {
@@ -56,13 +49,9 @@ final class Translator extends BaseTranslator implements WarmableInterface
             $this->addResources();
         }
 
-        parent::__construct($locale, $this->provideMessageFormatter($messageFormatterOrSelector), $this->options['cache_dir'], $this->options['debug']);
+        parent::__construct($locale, $messageFormatter, $this->options['cache_dir'], $this->options['debug']);
     }
 
-    /**
-     * @psalm-suppress MissingParamType
-     * @psalm-suppress MissingReturnType
-     */
     public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         // skip warmUp when translator doesn't use cache
@@ -70,7 +59,6 @@ final class Translator extends BaseTranslator implements WarmableInterface
             return [];
         }
 
-        /** @psalm-suppress InternalMethod */
         $locales = array_merge(
             $this->getFallbackLocales(),
             [$this->getLocale()],
@@ -172,29 +160,5 @@ final class Translator extends BaseTranslator implements WarmableInterface
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
             throw new \InvalidArgumentException(sprintf('The Translator does not support the following options: \'%s\'.', implode('\', \'', $diff)));
         }
-    }
-
-    /**
-     * @param mixed $messageFormatterOrSelector
-     */
-    private function provideMessageFormatter($messageFormatterOrSelector): MessageFormatterInterface
-    {
-        if ($messageFormatterOrSelector instanceof MessageSelector) {
-            @trigger_error(sprintf('Passing a "%s" instance into the "%s" as a third argument is deprecated since Sylius 1.2 and will be removed in 2.0. Inject a "%s" implementation instead.', MessageSelector::class, __METHOD__, MessageFormatterInterface::class), \E_USER_DEPRECATED);
-
-            /** @psalm-suppress InvalidArgument */
-            return new MessageFormatter($this, $messageFormatterOrSelector);
-        }
-
-        if ($messageFormatterOrSelector instanceof MessageFormatterInterface) {
-            return $messageFormatterOrSelector;
-        }
-
-        throw new \UnexpectedValueException(sprintf(
-            'Expected an instance of "%s" or "%s", got "%s"!',
-            MessageFormatterInterface::class,
-            MessageSelector::class,
-            is_object($messageFormatterOrSelector) ? get_class($messageFormatterOrSelector) : gettype($messageFormatterOrSelector),
-        ));
     }
 }

--- a/src/Twig/Loader/ThemedTemplateLoader.php
+++ b/src/Twig/Loader/ThemedTemplateLoader.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\ThemeBundle\Twig\Loader;
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
 use Sylius\Bundle\ThemeBundle\Twig\Locator\TemplateLocatorInterface;
 use Sylius\Bundle\ThemeBundle\Twig\Locator\TemplateNotFoundException;
-use Symfony\Component\Templating\TemplateReferenceInterface;
 use Twig\Loader\LoaderInterface as TwigLoaderInterface;
 use Twig\Source;
 
@@ -38,76 +37,52 @@ final class ThemedTemplateLoader implements LoaderInterface
         $this->themeContext = $themeContext;
     }
 
-    /**
-     * @param string|TemplateReferenceInterface $name
-     */
     public function getSourceContext($name): Source
     {
         try {
             $path = $this->locateTemplate($name);
 
-            /** @psalm-suppress RedundantCastGivenDocblockType */
             return new Source((string) file_get_contents($path), (string) $name, $path);
-        } catch (TemplateNotFoundException | \InvalidArgumentException $exception) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+        } catch (TemplateNotFoundException $exception) {
             return $this->decoratedLoader->getSourceContext($name);
         }
     }
 
-    /**
-     * @param string|TemplateReferenceInterface $name
-     */
     public function getCacheKey($name): string
     {
         try {
             return $this->locateTemplate($name);
-        } catch (TemplateNotFoundException | \InvalidArgumentException $exception) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+        } catch (TemplateNotFoundException $exception) {
             return $this->decoratedLoader->getCacheKey($name);
         }
     }
 
     /**
-     * @param string|TemplateReferenceInterface $name
      * @param int $time
      */
     public function isFresh($name, $time): bool
     {
         try {
             return filemtime($this->locateTemplate($name)) <= $time;
-        } catch (TemplateNotFoundException | \InvalidArgumentException $exception) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+        } catch (TemplateNotFoundException $exception) {
             return $this->decoratedLoader->isFresh($name, $time);
         }
     }
 
-    /**
-     * @param string|TemplateReferenceInterface $name
-     */
     public function exists($name): bool
     {
         try {
             return stat($this->locateTemplate($name)) !== false;
-        } catch (TemplateNotFoundException | \InvalidArgumentException $exception) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+        } catch (TemplateNotFoundException $exception) {
             return $this->decoratedLoader->exists($name);
         }
     }
 
     /**
-     * @psalm-assert string $template
-     *
-     * @param string|TemplateReferenceInterface $template
-     *
-     * @throws TemplateNotFoundException|\InvalidArgumentException
+     * @throws TemplateNotFoundException
      */
-    private function locateTemplate($template): string
+    private function locateTemplate(string $template): string
     {
-        if ($template instanceof TemplateReferenceInterface) {
-            // Symfony 4.x still pushes TemplateReferenceInterface to Twig loader (especially when warming up cache)
-            throw new \InvalidArgumentException(sprintf('Instances of "%s" are not supported.', TemplateReferenceInterface::class));
-        }
-
         $theme = $this->themeContext->getTheme();
 
         if ($theme === null) {


### PR DESCRIPTION
Use `#[AsCommand]` attribute instead of deprecated `Command::__construct(null)` pattern. Remove dead `TemplateReferenceInterface` code from removed `symfony/templating` package. Remove all `@psalm-suppress` annotations (Psalm was removed). Replace `get_class()` with `::class` syntax. Fix `?\Exception` to `?\Throwable` in exception constructor. Update LICENSE copyright. Clean up CI workflow. Fix `branch-alias` in `composer.json`.

Remove `MessageSelector` compatibility shim and `transChoice()` - both were [removed in Symfony 5.0](https://github.com/symfony/symfony/blob/5.0/src/Symfony/Component/Translation/CHANGELOG.md).