### PR TITLE
Respecting enabled locales

### DIFF
--- a/src/Resources/config/services/integrations/translations.php
+++ b/src/Resources/config/services/integrations/translations.php
@@ -44,6 +44,7 @@ return static function (ContainerConfigurator $container): void {
                 'cache_dir' => '%kernel.cache_dir%/translations',
                 'debug' => '%kernel.debug%',
             ],
+            '%kernel.enabled_locales%',
         ])
     ;
 

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -69,6 +69,7 @@ final class Translator extends BaseTranslator implements WarmableInterface
             [$this->getLocale()],
             $this->resourceProvider->getResourcesLocales(),
         );
+
         foreach (array_unique($locales) as $locale) {
             // reset catalogue in case it's already loaded during the dump of the other locales.
             if (isset($this->catalogues[$locale])) {

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -32,17 +32,22 @@ final class Translator extends BaseTranslator implements WarmableInterface
 
     private bool $resourcesLoaded = false;
 
+    /** @var array<string> */
+    private array $enabledLocales = [];
+
     public function __construct(
         TranslatorLoaderProviderInterface $loaderProvider,
         TranslatorResourceProviderInterface $resourceProvider,
         MessageFormatterInterface $messageFormatter,
         string $locale,
         array $options = [],
+        array $enabledLocales = [],
     ) {
         $this->assertOptionsAreKnown($options);
 
         $this->loaderProvider = $loaderProvider;
         $this->resourceProvider = $resourceProvider;
+        $this->enabledLocales = $enabledLocales;
 
         $this->options = array_merge($this->options, $options);
         if (null !== $this->options['cache_dir'] && $this->options['debug']) {
@@ -59,7 +64,7 @@ final class Translator extends BaseTranslator implements WarmableInterface
             return [];
         }
 
-        $locales = array_merge(
+        $locales = $this->enabledLocales ?: array_merge(
             $this->getFallbackLocales(),
             [$this->getLocale()],
             $this->resourceProvider->getResourcesLocales(),

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -282,6 +282,18 @@ final class TranslatorTest extends TestCase
         $this->assertEquals($catalogue, $translator->getCatalogue());
     }
 
+    /**
+     * @test
+     */
+    public function it_does_not_load_unused_locales(): void
+    {
+        $translator = $this->createTranslator('en', enabledLocales: ['en']);
+        $translator->setFallbackLocales(['en']);
+
+        $this->assertNotNull($translator->getCatalogue());
+        $this->assertCount(1, $translator->getCatalogues());
+    }
+
     public static function getInvalidLocalesTests(): array
     {
         return [
@@ -351,13 +363,14 @@ final class TranslatorTest extends TestCase
 
     /**
      * @param string[] $options
+     * @param string[] $enabledLocales
      */
-    private function createTranslator(string $locale = 'en', array $options = []): Translator
+    private function createTranslator(string $locale = 'en', array $options = [], array $enabledLocales = []): Translator
     {
         $loaderProvider = new TranslatorLoaderProvider();
         $resourceProvider = new SymfonyTranslatorResourceProvider();
         $messageFormatter = new MessageFormatter();
 
-        return new Translator($loaderProvider, $resourceProvider, $messageFormatter, $locale, $options);
+        return new Translator($loaderProvider, $resourceProvider, $messageFormatter, $locale, $options, $enabledLocales);
     }
 }


### PR DESCRIPTION
## Reasoning

Symfony and Sylius have a huge catalog of translations and every time you clear the cache they're getting recomputed If you know the target locales of your website you can limit what gets loaded and speed up compilation time.